### PR TITLE
Migrating references to yum::epel to new yum-epel cookbook

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -6,3 +6,4 @@
 Berksfile.lock
 Gemfile.lock
 \#*#
+.idea

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,10 @@
 ## 1.0.1
 
+* migrating from yum::epel to new yum-epel cookbook
+
+
+## 1.0.1
+
 * minitest fixes
 
 ## 1.0.0

--- a/README.md
+++ b/README.md
@@ -20,6 +20,7 @@ Installs [Protocol Buffer](https://code.google.com/p/protobuf/) C++, Java, and P
 * [apt](https://github.com/opscode-cookbooks/apt)
 * [build-essential](https://github.com/opscode-cookbooks/build-essential)
 * [yum](https://github.com/opscode-cookbooks/yum)
+* [yum-epel](https://github.com/opscode-cookbooks/yum-epel)
 
 ## Attributes
 

--- a/metadata.rb
+++ b/metadata.rb
@@ -4,7 +4,7 @@ maintainer_email  'bflad417@gmail.com'
 license           'Apache 2.0'
 description       'Installs/Configures Protocol Buffer'
 long_description  IO.read(File.join(File.dirname(__FILE__), 'README.md'))
-version           '1.0.1'
+version           '1.0.2'
 recipe            'protobuf', 'Installs Protocol Buffer'
 recipe            'protobuf::archive', 'Installs protobuf via archive'
 recipe            'protobuf::cpp', 'Installs protobuf C++'
@@ -18,6 +18,6 @@ recipe            'protobuf::python', 'Installs protobuf Python'
   supports os
 end
 
-%w{ apt build-essential yum }.each do |cb|
+%w{ apt build-essential yum yum-epel }.each do |cb|
   depends cb
 end

--- a/recipes/package_cpp.rb
+++ b/recipes/package_cpp.rb
@@ -1,5 +1,5 @@
 include_recipe 'apt' if node['platform'] == 'ubuntu'
-include_recipe 'yum::epel' if node['platform_family'] == 'rhel'
+include_recipe 'yum-epel' if node['platform_family'] == 'rhel'
 
 node['protobuf']['package']['cpp_packages'].each do |p|
   package p

--- a/recipes/package_java.rb
+++ b/recipes/package_java.rb
@@ -1,5 +1,5 @@
 include_recipe 'apt' if node['platform'] == 'ubuntu'
-include_recipe 'yum::epel' if node['platform_family'] == 'rhel'
+include_recipe 'yum-epel' if node['platform_family'] == 'rhel'
 
 node['protobuf']['package']['java_packages'].each do |p|
   package p

--- a/recipes/package_python.rb
+++ b/recipes/package_python.rb
@@ -1,5 +1,5 @@
 include_recipe 'apt' if node['platform'] == 'ubuntu'
-include_recipe 'yum::epel' if node['platform_family'] == 'rhel'
+include_recipe 'yum-epel' if node['platform_family'] == 'rhel'
 
 node['protobuf']['package']['python_packages'].each do |p|
   package p


### PR DESCRIPTION
Fixing issue with yum::epel cookbook include.
Looks like there was a major upstream release of the yum cookbook (3.X) that moved yum::epel recipe to a new yum-epel cookbook.

Se discussion here: https://github.com/bflad/chef-skyline/issues/1
