### PR TITLE
Bump protobuf to 2.6.0, update URL format.

### DIFF
--- a/attributes/default.rb
+++ b/attributes/default.rb
@@ -2,11 +2,11 @@ default['protobuf']['install_type'] = nil
 
 # Source attributes
 default['protobuf']['archive']['install_dir'] = '/usr/local'
-default['protobuf']['archive']['version'] = '2.5.0'
-default['protobuf']['archive']['url'] = "https://protobuf.googlecode.com/files/protobuf-#{node['protobuf']['archive']['version']}.tar.bz2"
+default['protobuf']['archive']['version'] = '2.6.0'
+default['protobuf']['archive']['url'] = "https://protobuf.googlecode.com/svn/rc/protobuf-#{node['protobuf']['archive']['version']}.tar.bz2"
 default['protobuf']['archive']['checksum'] =
   case node['protobuf']['archive']['version']
-  when '2.5.0' then '13bfc5ae543cf3aa180ac2485c0bc89495e3ae711fc6fab4f8ffe90dfb4bb677'
+  when '2.6.0' then '0a2f8533b2e0587a2b4efce0c4c8aea21bbfae1c41c466634d958dedf580f6aa'
   end
 
 # Package attributes


### PR DESCRIPTION
- The latest version of protobuf is 2.6.0
- The URL format has changed on https://code.google.com/p/protobuf/
