### PR TITLE
Protobuf26

### DIFF
--- a/.kitchen.yml
+++ b/.kitchen.yml
@@ -53,3 +53,8 @@ suites:
   - recipe[minitest-handler]
   - recipe[protobuf_test::default]
   attributes: {}
+- name: protobuf_archive
+  run_list:
+  - recipe[minitest-handler]
+  - recipe[protobuf_test::archive]
+  attributes: {}

--- a/.kitchen.yml
+++ b/.kitchen.yml
@@ -11,11 +11,6 @@ platforms:
     box: opscode-centos-6.5
     box_url: http://opscode-vm-bento.s3.amazonaws.com/vagrant/virtualbox/opscode_centos-6.5_chef-provisionerless.box
     require_chef_omnibus: latest
-- name: debian-7
-  driver_config:
-    box: opscode-debian-7.2.0
-    box_url: http://opscode-vm-bento.s3.amazonaws.com/vagrant/virtualbox/opscode_debian-7.2.0_chef-provisionerless.box
-    require_chef_omnibus: latest
 - name: fedora-19
   driver_config:
     box: opscode-fedora-19

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,7 @@
+## 1.2.1
+
+* Fix: Support new location of archive files.
+
 ## 1.2.0
 
 * Enhancement: Support Ubuntu 14.04+ C++ packages

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,7 @@
+## 1.3.0
+
+* Enhancement: Default archive installs to latest stable release of Protobuf (2.6.1).
+
 ## 1.2.1
 
 * Fix: Support new location of archive files.

--- a/README.md
+++ b/README.md
@@ -39,7 +39,7 @@ Attribute | Description | Type | Default
 checksum | SHA256 checksum for archive | String | auto-detected (see attributes/default.rb)
 install_dir | Installation prefix | String | /usr/local
 url | Archive URL | String | `https://github.com/google/protobuf/releases/download/v#{node['protobuf']['archive']['version']}/protobuf-#{node['protobuf']['archive']['version']}.tar.bz2`
-version | Archive version to install | String | 2.5.0
+version | Archive version to install | String | 2.6.1
 
 ### Package Attributes
 

--- a/README.md
+++ b/README.md
@@ -38,7 +38,7 @@ Attribute | Description | Type | Default
 ----------|-------------|------|--------
 checksum | SHA256 checksum for archive | String | auto-detected (see attributes/default.rb)
 install_dir | Installation prefix | String | /usr/local
-url | Archive URL | String | `https://protobuf.googlecode.com/files/protobuf-#{node['protobuf']['archive']['version']}.tar.bz2`
+url | Archive URL | String | `https://github.com/google/protobuf/releases/download/v#{node['protobuf']['archive']['version']}/protobuf-#{node['protobuf']['archive']['version']}.tar.bz2`
 version | Archive version to install | String | 2.5.0
 
 ### Package Attributes

--- a/attributes/default.rb
+++ b/attributes/default.rb
@@ -2,11 +2,13 @@ default['protobuf']['install_type'] = nil
 
 # Source attributes
 default['protobuf']['archive']['install_dir'] = '/usr/local'
-default['protobuf']['archive']['version'] = '2.5.0'
+default['protobuf']['archive']['version'] = '2.6.1'
 default['protobuf']['archive']['url'] = "https://github.com/google/protobuf/releases/download/v#{node['protobuf']['archive']['version']}/protobuf-#{node['protobuf']['archive']['version']}.tar.bz2"
 default['protobuf']['archive']['checksum'] =
   case node['protobuf']['archive']['version']
   when '2.5.0' then '13bfc5ae543cf3aa180ac2485c0bc89495e3ae711fc6fab4f8ffe90dfb4bb677'
+  when '2.6.0' then '0a2f8533b2e0587a2b4efce0c4c8aea21bbfae1c41c466634d958dedf580f6aa'
+  when '2.6.1' then 'ee445612d544d885ae240ffbcbf9267faa9f593b7b101f21d58beceb92661910'
   end
 
 # Package attributes

--- a/attributes/default.rb
+++ b/attributes/default.rb
@@ -3,7 +3,7 @@ default['protobuf']['install_type'] = nil
 # Source attributes
 default['protobuf']['archive']['install_dir'] = '/usr/local'
 default['protobuf']['archive']['version'] = '2.5.0'
-default['protobuf']['archive']['url'] = "https://protobuf.googlecode.com/files/protobuf-#{node['protobuf']['archive']['version']}.tar.bz2"
+default['protobuf']['archive']['url'] = "https://github.com/google/protobuf/releases/download/v#{node['protobuf']['archive']['version']}/protobuf-#{node['protobuf']['archive']['version']}.tar.bz2"
 default['protobuf']['archive']['checksum'] =
   case node['protobuf']['archive']['version']
   when '2.5.0' then '13bfc5ae543cf3aa180ac2485c0bc89495e3ae711fc6fab4f8ffe90dfb4bb677'

--- a/metadata.rb
+++ b/metadata.rb
@@ -4,7 +4,7 @@ maintainer_email 'bflad417@gmail.com'
 license 'Apache 2.0'
 description 'Installs/Configures Protocol Buffer'
 long_description IO.read(File.join(File.dirname(__FILE__), 'README.md'))
-version '1.2.1'
+version '1.3.0'
 
 recipe 'protobuf', 'Installs Protocol Buffer'
 recipe 'protobuf::archive', 'Installs protobuf via archive'

--- a/metadata.rb
+++ b/metadata.rb
@@ -4,7 +4,7 @@ maintainer_email 'bflad417@gmail.com'
 license 'Apache 2.0'
 description 'Installs/Configures Protocol Buffer'
 long_description IO.read(File.join(File.dirname(__FILE__), 'README.md'))
-version '1.2.0'
+version '1.2.1'
 
 recipe 'protobuf', 'Installs Protocol Buffer'
 recipe 'protobuf::archive', 'Installs protobuf via archive'

--- a/test/cookbooks/protobuf_test/CHANGELOG.md
+++ b/test/cookbooks/protobuf_test/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 This file is used to list changes made in each version of protobuf_test.
 
+## 0.2.0:
+
+* Added specific archive test.
+
 ## 0.1.0:
 
 * Initial release of docker_test

--- a/test/cookbooks/protobuf_test/README.md
+++ b/test/cookbooks/protobuf_test/README.md
@@ -23,6 +23,7 @@ Recipes
 -------
 
 * `default` - includes `protobuf::default`
+* `archive` - includes `protobuf::archive`
 
 Contributing
 ------------

--- a/test/cookbooks/protobuf_test/metadata.rb
+++ b/test/cookbooks/protobuf_test/metadata.rb
@@ -4,6 +4,6 @@ maintainer_email 'bflad417@gmail.com'
 license          'Apache 2.0'
 description      'Installs/Configures protobuf_test'
 long_description IO.read(File.join(File.dirname(__FILE__), 'README.md'))
-version          '0.1.0'
+version          '0.2.0'
 
 depends "protobuf"

--- a/test/cookbooks/protobuf_test/recipes/archive.rb
+++ b/test/cookbooks/protobuf_test/recipes/archive.rb
@@ -1,0 +1,1 @@
+include_recipe "protobuf::archive"


### PR DESCRIPTION
Hello,

This bit of work started as an effort to get the archive recipe up and running with a more recent stable release of protobuf (v.2.6.1). 

The main change surrounds the url in which protobuf is downloaded from. The protobuf project has since moved off of googlecode and over to GitHub and now uses the project release page to publish releases. They relocated previous released versions of protobuf to GitHub as well as the new ones. 

It wasn't until the last commit that I changed the default version of the protobuf archive being requested. A new tests suite was also created to specifically invoke the protobuf::archive recipe. 
